### PR TITLE
Nate's rule

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -112,9 +112,9 @@ LintOptions(::Colon) = LintOptions(fill(true, length(default_options))...)
 LintOptions(options::Vararg{Union{Bool,Nothing},length(default_options)}) =
     LintOptions(something.(options, default_options)...)
 
-function check_all(x::EXPR, opts::LintOptions, env::ExternalEnv, markers::Dict{Symbol,Symbol}=Dict{Symbol,Symbol}())
+function check_all(x::EXPR, opts::LintOptions, env::ExternalEnv, markers::Dict{Symbol,String}=Dict{Symbol,String}())
     if headof(x) === :const
-        markers[:const] = :const
+        markers[:const] = "const"
     end
 
     # Do checks


### PR DESCRIPTION
> rule in the compiler that warns for array literals without types ([] vs. T[]), but wouldn't presume to impose that on the entire code base.

[Slack discussion](https://relationalai.slack.com/archives/C81MWT3QQ/p1709281267592879?thread_ts=1709217251.907129&cid=C81MWT3QQ)