### PR TITLE
Check proper string interpolation

### DIFF
--- a/src/linting/checks.jl
+++ b/src/linting/checks.jl
@@ -361,7 +361,9 @@ function check_call(x, env::ExternalEnv)
 
                 func_ref.name.name in [:copy] && return
             end
-            function_name = fetch_value(func_ref.name, :IDENTIFIER)
+            function_name = func_ref.name isa SymbolServer.FakeTypeName ?
+                                fetch_value(func_ref.name.name, :IDENTIFIER) :
+                                fetch_value(func_ref.name, :IDENTIFIER)
             function_name in ["delete!", "copy", "copy!", "write", "hash", "iterate"] && return
             seterror!(x, "Possible method call error: $(function_name).")
         end


### PR DESCRIPTION
This PR makes the following tests green:
```Julia
@testset "Checking string interpolation" begin
    source_with_error = raw"""
    function f(conf)
        @info "($conf.container.baseurl)"
    end
    """

    source_without_error = raw"""
    function f(conf)
        @info "$(conf.container.baseurl)"
    end
    """

    @test lint_test(source_with_error, raw"Line 2, column 11: Suspicious string interpolation, you may want to have $(a.b.c) instead of ($a.b.c).")
    @test count_lint_errors(source_without_error) == 0
end
```

This programming mistake caused a security incident. Thanks to this PR, we should avoid such a situation in the future.

[Discussion on Slack](https://relationalai.slack.com/archives/C04J1BRVD40/p1721039021983169)