### PR TITLE
Compute offsets properly for files containing UTF strings

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -159,8 +159,8 @@ end
 # annotation could be either nothing, "lint-disable-line", or
 # "lint-disable-line ERROR_MSG_TO_IGNORE"
 #
-# Note: `offset` is measured in codepoints.  The returned `index_column` is an index (which
-# is a codepoint offset).
+# Note: `offset` is measured in codepoints.  The returned `index_column` is a character
+# index (not a string index).
 function convert_offset_to_line_from_lines(offset::Int, all_lines)
     offset < 0 && throw(BoundsError("source", offset))
 
@@ -187,7 +187,7 @@ function convert_offset_to_line_from_lines(offset::Int, all_lines)
             else
                 annotation = nothing
             end
-            result = index_line, (offset - current_codepoint + 1), annotation
+            result = index_line, length(line, 1, (offset - current_codepoint + 1)), annotation
             annotation = nothing
             return result
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,10 +33,11 @@ include(joinpath(@__DIR__, "rai_rules_tests.jl"))
         @test convert_offset_to_line_from_lines(11, ["# ─aaa","abcdegh"]) == (2,2,nothing)
         @test convert_offset_to_line_from_lines(
             40, ["# aaaaaaaaaa", "aaaa", "bbbb", "cccc", "dddd", "eeee","ffff"]
-        ) == (7, 1, nothing)
+        ) == (7, 2, nothing)
         @test convert_offset_to_line_from_lines(
             40, ["# ──────────", "aaaa", "bbbb", "cccc", "dddd", "eeee","ffff"]
-        ) == (3, 1, nothing)
+        ) == (3, 2, nothing)
+        @test convert_offset_to_line_from_lines(4, ["──"]) == (1,2,nothing)
     end
 
     @testset "Basic bindings" begin


### PR DESCRIPTION
Fixes [RAI-28516](https://relationalai.atlassian.net/browse/RAI-28516).

[RAI-28516]: https://relationalai.atlassian.net/browse/RAI-28516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ