### PR TITLE
Add lint rules to prevent usage of Shape outside the front-end compiler

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -553,8 +553,10 @@ function check(t::NonFrontShapeAPIUsage_Extension, x::EXPR, markers::Dict{Symbol
     contains(markers[:filename], "src/Compiler/front2back.jl") && return
     contains(markers[:filename], "src/FFI") && return
 
-    generic_check(t, x, "shape_term(hole_variable_star)", "Usage of `shape_term` is not allowed outside of the Front-end Compiler and FFI.")
-    generic_check(t, x, "shape_splat(hole_variable_star)", "Usage of `shape_splat` is not allowed outside of the Front-end Compiler and FFI.")
+    generic_check(t, x, "shape_term(hole_variable_star)", "Usage of `shape_term` Shape API method is not allowed outside of the Front-end Compiler and FFI.")
+    generic_check(t, x, "Front.shape_term(hole_variable_star)", "Usage of `shape_term` Shape API method is not allowed outside of the Front-end Compiler and FFI.")
+    generic_check(t, x, "shape_splat(hole_variable_star)", "Usage of `shape_splat` Shape API method is not allowed outside of the Front-end Compiler and FFI.")
+    generic_check(t, x, "Front.shape_splat(hole_variable_star)", "Usage of `shape_splat` Shape API method is not allowed outside of the Front-end Compiler and FFI.")
     generic_check(t, x, "ffi_shape_term(hole_variable_star)", "Usage of `ffi_shape_term` is not allowed outside of the Front-end Compiler and FFI.")
     generic_check(t, x, "Shape", "Usage of `Shape` is not allowed outside of the Front-end Compiler and FFI.")
 end

--- a/test/rai_rules_tests.jl
+++ b/test/rai_rules_tests.jl
@@ -1886,12 +1886,12 @@ end
     @test count_lint_errors(source; directory="/src/Compiler/Front") == 0
 
     @test lint_test(source,
-        "Line 1, column 63: Usage of `Shape` is not allowed outside of the Front-end Compiler and FFI.";
+        "Line 1, column 67: Usage of `Shape` is not allowed outside of the Front-end Compiler and FFI.";
         directory="/src/Execution"
     )
 
     @test lint_test(source,
-        "Line 7, column 48: Usage of `shape_splat` Shape API method is not allowed outside of the Front-end Compiler and FFI.";
+        "Line 7, column 46: Usage of `shape_splat` Shape API method is not allowed outside of the Front-end Compiler and FFI.";
         directory="/src/Execution"
     )
 end


### PR DESCRIPTION
Adds lint rules to prevent the usage of `Shape`-related methods outside the front-end compiler.

Fixes [RAI-27513](https://relationalai.atlassian.net/browse/RAI-27513)

[RAI-27513]: https://relationalai.atlassian.net/browse/RAI-27513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ