### PR TITLE
Fix path logic for the Shape rule

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -549,9 +549,11 @@ end
 function check(t::NonFrontShapeAPIUsage_Extension, x::EXPR, markers::Dict{Symbol,String})
     haskey(markers, :filename) || return
     # In the front-end and in FFI, we are allowed to refer to `Shape`
-    contains(markers[:filename], "src/Compiler/Front") || return
-    contains(markers[:filename], "src/Compiler/front2back.jl") || return
-    contains(markers[:filename], "src/FFI") || return
+    contains(markers[:filename], "src/Compiler/Front") && return
+    contains(markers[:filename], "src/Compiler/front2back.jl") && return
+    contains(markers[:filename], "src/FFI") && return
+    # Also, allow usages in tests
+    contains(markers[:filename], "test/") && return
 
     generic_check(t, x, "shape_term(hole_variable_star)", "Usage of `shape_term` Shape API method is not allowed outside of the Front-end Compiler and FFI.")
     generic_check(t, x, "Front.shape_term(hole_variable_star)", "Usage of `shape_term` Shape API method is not allowed outside of the Front-end Compiler and FFI.")


### PR DESCRIPTION
`Shape` is allowed in front-end compiler directories **and** in tests