### PR TITLE
Reporting `showerror`

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -219,6 +219,8 @@ struct InterpolationInSafeLogRule <: RecommendationLintRule end
 struct UseOfStaticThreads <: ViolationLintRule end
 struct LogStatementsMustBeSafe <: FatalLintRule end
 
+struct ShowErrorReporting <: RecommendationLintRule end
+
 const all_extended_rule_types = Ref{Any}(
     vcat(
         InteractiveUtils.subtypes(RecommendationLintRule),
@@ -585,3 +587,8 @@ function check(t::LogStatementsMustBeSafe, x::EXPR)
     end
 end
 
+function check(t::ShowErrorReporting, x::EXPR)
+    msg = "Reporting with `showerror(...)` instead of `safe_showerror(...)` could leak sensitive data."
+    # generic_check(t, x, "showerror(hole_variable_star)", msg)
+    generic_check(t, x, "showerror", msg)
+end

--- a/test/rai_rules_tests.jl
+++ b/test/rai_rules_tests.jl
@@ -1959,7 +1959,7 @@ end
             precompile_statement=@safe(repr(statement)),
             # Log the message that the exception would print, else JSONLogger logs each of
             # the fields of the exception separately which is much less useful.
-            exception=@safe(sprint(showerror, e)),
+            exception=@safe(sprint(show, e)),
             maxlog=100,
         )
     end
@@ -2027,4 +2027,19 @@ end
         end
         @test result_matching
     end
+end
+
+@testset "showerror reporting" begin
+    source = """
+        function rusage()
+            showerror("an error")
+            map(showerror, ["a", "b"]);
+            safe_showerror("an error")
+        end
+        """
+    @test count_lint_errors(source) == 2
+    @test lint_test(source,
+        "Line 2, column 5: Reporting with `showerror(...)` instead of `safe_showerror(...)` could leak sensitive data.")
+    @test lint_test(source,
+        "Line 3, column 9: Reporting with `showerror(...)` instead of `safe_showerror(...)` could leak sensitive data.")
 end


### PR DESCRIPTION
The following unit test is green:

```Julia
@testset "showerror reporting" begin
    source = """
        function rusage()
            showerror("an error")
            map(showerror, ["a", "b"]);
            safe_showerror("an error")
        end
        """
    @test count_lint_errors(source) == 2
    @test lint_test(source,
        "Line 2, column 5: Reporting with `showerror(...)` instead of `safe_showerror(...)` could leak sensitive data.")
    @test lint_test(source,
        "Line 3, column 9: Reporting with `showerror(...)` instead of `safe_showerror(...)` could leak sensitive data.")
end
```